### PR TITLE
[ENG-45] ci: disable husky for the release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,5 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  HUSKY: 0
               run: npm run semantic-release


### PR DESCRIPTION
This disable husky for the commits that are done by semantic-release itself. When testing the manual release job that prevents the release due to pre-commit hooks (which is only meant to enforce developer commits)