### PR TITLE
[ENG-5397] Add style options to start options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,31 @@ const { startConnect } = useStackOneHub();
 startConnect(options)
 ```
 
+### Style Options
+You may pass a few style options to customize the Connect flow.
+
+All of the following are optional.
+```jsx
+// Example of styles object
+const styles = {
+  inline: {
+    containerId: 'my-container-id',
+    height: '500px',
+    width: '300px',
+  },
+  options: {
+    back: false,
+    close: false,
+    bgColor: 'white',
+  },
+};
+```
+
 | Name                    | Type        | Required    | Description         |
 | ----------------------- | ----------- | ----------- | ------------------- |
 | **sessionToken**        | string      | **Yes**     | Connect session token created in the backend. The session token allows users to manage their accounts in the frontend. You may limit a connect session token to selected categories or to a given service
 | **apiUrl**              | string      | No          | Which API instance should it connect to. It will automatically infer it from your connect session.
+| **styles**              | ConnectStyles      | No          | Customize the aspect of the Connect flow.
 | **onSuccess(account)**  | function    | No          | Called when an account is successfully linked. The `account` param gives you information about the linked account.
 | **onCancel()**          | function    | No          | Called when the connect flow is closed without an account being linked.
 | **onClose()**           | function    | No          | Called every time the connect flow is closed regardless of whether an account has been linked or not.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const styles = {
 | ----------------------- | ----------- | ----------- | ------------------- |
 | **sessionToken**        | string      | **Yes**     | Connect session token created in the backend. The session token allows users to manage their accounts in the frontend. You may limit a connect session token to selected categories or to a given service
 | **apiUrl**              | string      | No          | Which API instance should it connect to. It will automatically infer it from your connect session.
-| **styles**              | ConnectStyles      | No          | Customize the aspect of the Connect flow.
+| **styles**              | HubStyles      | No          | Customize the aspect of the Connect flow.
 | **onSuccess(account)**  | function    | No          | Called when an account is successfully linked. The `account` param gives you information about the linked account.
 | **onCancel()**          | function    | No          | Called when the connect flow is closed without an account being linked.
 | **onClose()**           | function    | No          | Called every time the connect flow is closed regardless of whether an account has been linked or not.

--- a/src/entities/ConnectStyles.ts
+++ b/src/entities/ConnectStyles.ts
@@ -1,0 +1,16 @@
+interface InlineStyles {
+    containerId: string;
+    width?: string;
+    height?: string;
+}
+
+interface OptionsStyles {
+    back?: boolean;
+    close?: boolean;
+    bgColor?: string;
+}
+
+export interface ConnectStyles {
+    inline?: InlineStyles;
+    options?: OptionsStyles;
+}

--- a/src/entities/HubStyles.ts
+++ b/src/entities/HubStyles.ts
@@ -10,7 +10,7 @@ interface OptionsStyles {
     bgColor?: string;
 }
 
-export interface ConnectStyles {
+export interface HubStyles {
     inline?: InlineStyles;
     options?: OptionsStyles;
 }

--- a/src/entities/StartOptions.ts
+++ b/src/entities/StartOptions.ts
@@ -1,10 +1,10 @@
 import { Account } from './Account';
-import { ConnectStyles } from './ConnectStyles';
+import { HubStyles } from './HubStyles';
 
 export interface StartOptions {
     sessionToken: string;
     apiUrl?: string;
-    styles?: ConnectStyles;
+    styles?: HubStyles;
     onSuccess?: (account: Account) => void;
     onCancel?: () => void;
     onClose?: () => void;

--- a/src/entities/StartOptions.ts
+++ b/src/entities/StartOptions.ts
@@ -1,8 +1,10 @@
 import { Account } from './Account';
+import { ConnectStyles } from './ConnectStyles';
 
 export interface StartOptions {
     sessionToken: string;
     apiUrl?: string;
+    styles?: ConnectStyles;
     onSuccess?: (account: Account) => void;
     onCancel?: () => void;
     onClose?: () => void;


### PR DESCRIPTION
- Added `styles?: ConnectStyle` to the `StartOptions` so users can customize the hub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced customizable style options for the Connect flow, allowing users to modify appearance through an optional `styles` object.
	- Added detailed examples and parameters for the new styling options in the documentation.

- **Documentation**
	- Updated the README.md to include a new "Style Options" section and modified the `startConnect` function's parameter table to reflect the addition of the `styles` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->